### PR TITLE
[Feat] develop 브랜치에 PR 적용시 Github Actions 작동되게 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,9 @@ env:
   IMAGE_TAG: 1.0.0
 
 on:
-  push:
+  pull_request:
     branches:
-      - feat/ci-cd
+      - develop
 
 jobs:
 


### PR DESCRIPTION

## 📝작업 내용
기존의 백엔드 CI/CD 환경 구성 때문에 feat/ci-cd 브랜치로 push시 CI/CD 작동하던 것을 실제 배포환경에서만 CI/CD를 적용할 필요가 있다고 판단하여 Github Actions deploy.yml `on` 부분을 수정하였습니다.